### PR TITLE
PX4LogReader: allow microsecond timestamps for APM logs

### DIFF
--- a/src/me/drton/jmavlib/log/px4/PX4LogReader.java
+++ b/src/me/drton/jmavlib/log/px4/PX4LogReader.java
@@ -30,6 +30,8 @@ public class PX4LogReader extends BinaryLogReader {
     private Map<String, Object> version = new HashMap<String, Object>();
     private Map<String, Object> parameters = new HashMap<String, Object>();
     private List<Exception> errors = new ArrayList<Exception>();
+    private String tsName = null;
+    private boolean tsMicros;
 
     private static Set<String> hideMsgs = new HashSet<String>();
     private static Map<String, String> formatNames = new HashMap<String, String>();
@@ -182,7 +184,10 @@ public class PX4LogReader extends BinaryLogReader {
                         } else {
                             int fix = ((Number) msg.get("Status")).intValue();
                             int week = ((Number) msg.get("Week")).intValue();
-                            long ms = ((Number) msg.get("TimeMS")).longValue();
+                            long ms = ((Number) msg.get(tsName)).longValue();
+                            if (tsMicros)  {
+                                ms = ms / 1000;
+                            }
                             if (fix >= 3 && (week > 0 || ms > 0)) {
                                 long leapSeconds = 16;
                                 long gpsT = ((315964800L + week * 7L * 24L * 3600L - leapSeconds) * 1000 + ms) * 1000L;
@@ -243,10 +248,13 @@ public class PX4LogReader extends BinaryLogReader {
                         buffer.position(buffer.position() + bodyLen);
                     }
                 } else {
-                    Integer idx = messageDescription.fieldsMap.get("TimeMS");
+                    Integer idx = messageDescription.fieldsMap.get(tsName);
                     if (idx != null && idx == 0) {
                         PX4LogMessage msg = messageDescription.parseMessage(buffer);
-                        long t = msg.getLong(idx) * 1000;
+                        long t = msg.getLong(idx);
+                        if (!tsMicros) {
+                            t *=1000;
+                        }
                         if (t > seekTime) {
                             // Time found
                             time = t;
@@ -264,10 +272,28 @@ public class PX4LogReader extends BinaryLogReader {
         }
     }
 
+    // return ts in micros
     private long getAPMTimestamp(PX4LogMessage msg) {
-        Integer idx = msg.description.fieldsMap.get("TimeMS");
+        if (null == tsName) {
+            // detect APM's timestamp format on first timestamp seen
+            if (null != msg.description.fieldsMap.get("TimeUS")) {
+                // new format, timestamps in micros
+                tsMicros = true;
+                tsName = "TimeUS";
+            }
+            else if (null != msg.description.fieldsMap.get("TimeMS")){
+                // old format, timestamps in millis
+                tsMicros = false;
+                tsName = "TimeMS";
+            }
+            else {
+                return 0;
+            }
+        }
+
+        Integer idx = msg.description.fieldsMap.get(tsName);
         if (idx != null && idx == 0) {
-            return msg.getLong(idx) * 1000;
+            return tsMicros ? msg.getLong(idx) : (msg.getLong(idx) * 1000);
         }
         return 0;
     }
@@ -276,7 +302,7 @@ public class PX4LogReader extends BinaryLogReader {
         String[] fields = msg.description.fields;
         for (int i = 0; i < fields.length; i++) {
             String field = fields[i];
-            if (i != 0 || !"TimeMS".equals(field)) {
+            if (i != 0 || !tsName.equals(field)) {
                 update.put(msg.description.name + "." + field, msg.get(i));
             }
         }
@@ -358,7 +384,7 @@ public class PX4LogReader extends BinaryLogReader {
                             for (int i = 0; i < msgDescr.fields.length; i++) {
                                 String field = msgDescr.fields[i];
                                 String format = formatNames.get(Character.toString(msgDescr.format.charAt(i)));
-                                if (i != 0 || !"TimeMS".equals(field)) {
+                                if (i != 0 || !("TimeMS".equals(field)||"TimeUS".equals(field))) {
                                     fieldsList.put(msgDescr.name + "." + field, format);
                                 }
                             }

--- a/src/me/drton/jmavlib/log/px4/PX4LogReader.java
+++ b/src/me/drton/jmavlib/log/px4/PX4LogReader.java
@@ -230,7 +230,7 @@ public class PX4LogReader extends BinaryLogReader {
                 try {
                     fillBuffer(bodyLen);
                 } catch (EOFException e) {
-                    errors.add(new FormatErrorException(pos, "Unexpected end of file"));
+                    //errors.add(new FormatErrorException(pos, "Unexpected end of file"));
                     throw e;
                 }
                 if (formatPX4) {
@@ -452,7 +452,7 @@ public class PX4LogReader extends BinaryLogReader {
             try {
                 fillBuffer(messageDescription.length - HEADER_LEN);
             } catch (EOFException e) {
-                errors.add(new FormatErrorException(pos, "Unexpected end of file"));
+                //errors.add(new FormatErrorException(pos, "Unexpected end of file"));
                 throw e;
             }
             return messageDescription.parseMessage(buffer);


### PR DESCRIPTION
FlightPlot crashes or fails in other ways when loading recent (3.4-dev) APM log files. The reason is that APM has switched to microsecond timestamps recently and the ts field has been renamed to TimeUS instead of TimeMS.
